### PR TITLE
Added some configuration for PHP into phpunit.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Composer files
 composer.phar
 vendor/
+phpunit.xml
 
 # IDE files
 .idea/

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/autoload.php">
+<phpunit>
     <testsuites>
         <testsuite name="ZF\Geocoder Tests">
             <directory>./test</directory>
@@ -11,4 +10,11 @@
             <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>
+
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <ini name="display_errors" value="On"/>
+        <ini name="log_errors" value="0"/>
+        <ini name="memory_limit" value="-1"/>
+    </php>
 </phpunit>


### PR DESCRIPTION
Renamed `phpunit.xml` to `phpunti.xml.dist` so everyone can overwrite it.

Also changed some config values for PHP when running unit tests:

- error_reporting (-1): makes sure every error is show, regardless of PHP version
- display_errors (on): show errors. Some people have this turned off
- log_errors (0): prevents errors to be logged twice
- memory_limit (-1): make sure PHPUnit can consume as much memory as needed. Some people have this set to weird values for CLI
